### PR TITLE
refactors css to add media query for a max-width of 430px

### DIFF
--- a/src/Components/FiveDayPollenForecast/FiveDayPollenForecast.css
+++ b/src/Components/FiveDayPollenForecast/FiveDayPollenForecast.css
@@ -21,11 +21,11 @@ h2 {
 }
 
 .search-container {
-    margin: 10px; 
+    margin: 10px;
 }
 
 .allergen-drop-down,
-.scale-level-drop-down, 
+.scale-level-drop-down,
 .search-button,
 .clear-search-results-button {
     margin: 5px;
@@ -42,14 +42,17 @@ h2 {
 
 @media (max-width: 480px) {
     h2 {
-      font-size: 17px;
+        font-size: 17px;
     }
+
     .five-day-pollen-forecast-link-in-current-pollen-forecast {
         font-size: 15px;
     }
+
     label {
         font-size: 16px;
     }
+
     .five-day-pollen-forecast-cards-wrapper {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
@@ -57,27 +60,50 @@ h2 {
         margin-top: 12px;
         padding: 0 15px;
     }
+
     .pollen-scale {
         font-size: 20px;
     }
+
     .category-scale {
         font-size: 17px;
     }
+}
+
+@media (max-width: 430px) {
+    h2 {
+        font-size: 16px;
+    }
+
+    .current-pollen-forecast-link-in-five-day-pollen-forecast {
+        font-size: 16px;
+    }
+
+    label {
+        font-size: 13px
+    }
+
+    .pollen-scale {
+        font-size: 16px;
+    }
+
+    .category-scale {
+        font-size: 13px;
+    }    
 }
 
 @media (max-width: 394px) {
     h2 {
         font-size: 15px;
     }
+
     .current-pollen-forecast-link-in-five-day-pollen-forecast {
         font-size: 15px;
     }
+
     label {
         font-size: 12.5px
     }
-    /* .clear-search-results-button {
-        font-size: 12px;
-    } */
 
     .pollen-scale {
         font-size: 15px;
@@ -86,5 +112,4 @@ h2 {
     .category-scale {
         font-size: 12px;
     }
-
 }

--- a/src/Components/FiveDayPollenForecastCard/FiveDayPollenForecastCard.css
+++ b/src/Components/FiveDayPollenForecastCard/FiveDayPollenForecastCard.css
@@ -1,49 +1,65 @@
 .five-day-pollen-forecast-card {
-    box-sizing: border-box;
-    border: 3px solid black;
-    padding: 10px;
+  box-sizing: border-box;
+  border: 3px solid black;
+  padding: 10px;
 }
 
 @media (max-width: 480px) {
-    h3 {
-      font-size: 13px;
-    }
-  
-    .five-day-pollen-forecast-card-p-element {
-      font-size: 12.5px;
-    }
-  }
-  @media (max-width: 394px) {
-    .five-day-pollen-forecast-card {
-        box-sizing: border-box;
-        border: 2.5px solid black;
-        padding: 8px;
-    }
-   
-    h3 {
-      font-size: 11.5px;
-    }
-  
-    .five-day-pollen-forecast-card-p-element {
-      font-size: 11px;
-    }
+  h3 {
+    font-size: 13px;
   }
 
-  @media (max-width: 370px) {
-    
-    h3 {
-        margin-top: 8px;
-        margin-bottom: 8px;
-    }
-
-    p {
-        margin-top: 8px;
-        margin-bottom: 8px;
-    }
-    .five-day-pollen-forecast-card {
-        box-sizing: border-box;
-        border: 2px solid black;
-        padding: 8px;
-    }
+  .five-day-pollen-forecast-card-p-element {
+    font-size: 12.5px;
   }
-  
+}
+
+@media (max-width: 430px) {
+  h3 {
+    font-size: 12px;
+  }
+
+  .five-day-pollen-forecast-card-p-element {
+    font-size: 11.5px;
+  }
+
+  .five-day-pollen-forecast-card {
+    box-sizing: border-box;
+    border: 2.5px solid black;
+    padding: 8.5px;
+  }
+}
+
+@media (max-width: 394px) {
+  h3 {
+    font-size: 11.5px;
+  }
+
+  .five-day-pollen-forecast-card-p-element {
+    font-size: 11px;
+  }
+
+  .five-day-pollen-forecast-card {
+    box-sizing: border-box;
+    border: 2.5px solid black;
+    padding: 8px;
+  }
+}
+
+@media (max-width: 370px) {
+  h3 {
+    margin-top: 8px;
+    margin-bottom: 8px;
+  }
+
+  .five-day-pollen-forecast-card-p-element {
+    margin-top: 8px;
+    margin-bottom: 8px;
+  }
+
+  .five-day-pollen-forecast-card {
+    box-sizing: border-box;
+    border: 2px solid black;
+    padding: 8px;
+  }
+}

--- a/src/Components/Footer/Footer.css
+++ b/src/Components/Footer/Footer.css
@@ -16,7 +16,7 @@
 
 @media (max-width: 394px) {
     .footer {
-        height: 6.5rem;
+        height: 6rem;
   }
 
   p {


### PR DESCRIPTION
**What does this PR do?**
- After merging the prior changes, I used the google dev tools device size simulator to confirm application was responsive across appropriate devices. I discovered the application needed an additional media query between 394px and 430px for the 5-Day Pollen Forecast page. I added a max-width media query of 430px to the FiveDayPollenForecast, FiveDayPollenForecastCard, and Footer css files. 

**What are the relevant tickets (if any)?**
- https://github.com/kiewi16/pollen-pal/issues/8 is linked to this PR, and will be closed upon successful completion of the merge. This ticket was originally linked to the prior PR; however, after merging the changes with main, I realized additional refactoring was required and therefore did not close the ticket. 