### PR TITLE
adds after http to two network requests as well as to Cypress testing

### DIFF
--- a/cypress/e2e/CurrentPollenForecast.cy.js
+++ b/cypress/e2e/CurrentPollenForecast.cy.js
@@ -1,13 +1,13 @@
 describe('Current Pollen Forecast Page Tests', () => {
     beforeEach(() => {
         cy.fixture('currentpollenforecast').then((currentpollenforecast) => {
-            cy.intercept('GET', 'http://dataservice.accuweather.com/forecasts/v1/daily/1day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&details=true', {
+            cy.intercept('GET', 'https://dataservice.accuweather.com/forecasts/v1/daily/1day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&details=true', {
                 statusCode: 200,
                 body: currentpollenforecast
             })
         })
         cy.fixture('fivedaypollenforecast').then((fivedaypollenforecast) => {
-            cy.intercept('GET', 'http://dataservice.accuweather.com/forecasts/v1/daily/5day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&language=en-us&details=true&metric=false', {
+            cy.intercept('GET', 'https://dataservice.accuweather.com/forecasts/v1/daily/5day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&language=en-us&details=true&metric=false', {
                 statusCode: 200,
                 body: fivedaypollenforecast
             })

--- a/cypress/e2e/FiveDayPollenForecast.cy.js
+++ b/cypress/e2e/FiveDayPollenForecast.cy.js
@@ -1,13 +1,13 @@
 describe('5-Day Pollen Forecast Page Tests', () => {
     beforeEach(() => {
         cy.fixture('currentpollenforecast').then((currentpollenforecast) => {
-            cy.intercept('GET', 'http://dataservice.accuweather.com/forecasts/v1/daily/1day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&details=true', {
+            cy.intercept('GET', 'https://dataservice.accuweather.com/forecasts/v1/daily/1day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&details=true', {
                 statusCode: 200,
                 body: currentpollenforecast
             })
         })
         cy.fixture('fivedaypollenforecast').then((fivedaypollenforecast) => {
-            cy.intercept('GET', 'http://dataservice.accuweather.com/forecasts/v1/daily/5day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&language=en-us&details=true&metric=false', {
+            cy.intercept('GET', 'https://dataservice.accuweather.com/forecasts/v1/daily/5day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&language=en-us&details=true&metric=false', {
                 statusCode: 200,
                 body: fivedaypollenforecast
             })

--- a/cypress/e2e/GetRequestSadPaths.cy.js
+++ b/cypress/e2e/GetRequestSadPaths.cy.js
@@ -1,13 +1,13 @@
 describe('Get Request Sad Paths', () => {
     it('should display a message to the user if the network request for current pollen forecast data is unsuccessful', () => {
-        cy.intercept('GET', 'http://dataservice.accuweather.com/forecasts/v1/daily/1day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&details=true', {
+        cy.intercept('GET', 'https://dataservice.accuweather.com/forecasts/v1/daily/1day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&details=true', {
             statusCode: 500,
         })
         cy.visit('http://localhost:3000/CurrentPollenForecast')
         cy.get('.error-message').should('contain', "We've encountered an unexpected error and were unable to get the current pollen forecast for Highlands Ranch, CO. Please try again later.")
     })
     it('should display a message to the user if the network request for 5-day forecast data is unsuccessful', () => {
-        cy.intercept('GET', 'http://dataservice.accuweather.com/forecasts/v1/daily/5day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&language=en-us&details=true&metric=false', {
+        cy.intercept('GET', 'https://dataservice.accuweather.com/forecasts/v1/daily/5day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&language=en-us&details=true&metric=false', {
             statusCode: 500,
         })
         cy.visit('http://localhost:3000/FiveDayPollenForecast')

--- a/cypress/e2e/HomePage.cy.js
+++ b/cypress/e2e/HomePage.cy.js
@@ -1,13 +1,13 @@
 describe('Home Page Tests', () => {
   beforeEach(() => {
     cy.fixture('currentpollenforecast').then((currentpollenforecast) => {
-      cy.intercept('GET', 'http://dataservice.accuweather.com/forecasts/v1/daily/1day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&details=true', {
+      cy.intercept('GET', 'https://dataservice.accuweather.com/forecasts/v1/daily/1day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&details=true', {
         statusCode: 200,
         body: currentpollenforecast
       })
     })
     cy.fixture('fivedaypollenforecast').then((fivedaypollenforecast) => {
-      cy.intercept('GET', 'http://dataservice.accuweather.com/forecasts/v1/daily/5day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&language=en-us&details=true&metric=false', {
+      cy.intercept('GET', 'https://dataservice.accuweather.com/forecasts/v1/daily/5day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&language=en-us&details=true&metric=false', {
         statusCode: 200,
         body: fivedaypollenforecast
       })

--- a/src/Components/CurrentPollenForecast/CurrentPollenForecast.js
+++ b/src/Components/CurrentPollenForecast/CurrentPollenForecast.js
@@ -15,7 +15,7 @@ function CurrentPollenForecast() {
     const [searchResultsMessage, setSearchResultsMessage] = useState("")
 
     function getCurrentPollenForecast() {
-        fetch('http://dataservice.accuweather.com/forecasts/v1/daily/1day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&details=true')
+        fetch('https://dataservice.accuweather.com/forecasts/v1/daily/1day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&details=true')
             .then(response => {
                 if (!response.ok) {
                     throw new Error("We've encountered an unexpected error and were unable to get the current pollen forecast for Highlands Ranch, CO. Please try again later.")

--- a/src/Components/FiveDayPollenForecast/FiveDayPollenForecast.js
+++ b/src/Components/FiveDayPollenForecast/FiveDayPollenForecast.js
@@ -16,7 +16,7 @@ function FiveDayPollenForecast() {
     const [searchResultsMessage, setSearchResultsMessage] = useState("")
 
     function getFiveDayPollenForecast() {
-        fetch('http://dataservice.accuweather.com/forecasts/v1/daily/5day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&language=en-us&details=true&metric=false')
+        fetch('https://dataservice.accuweather.com/forecasts/v1/daily/5day/337466?apikey=RlGJ3tQAAtATkTkWTQvIt9Mhy7FG2RS1&language=en-us&details=true&metric=false')
             .then(response => {
                 if(!response.ok) {
                     throw new Error("We've encountered an unexpected error and were unable to get the pollen forecast for Highlands Ranch, CO. Please try again later.")


### PR DESCRIPTION
**What does this PR do?**
- A bug was discovered during Vercel deployment that is likely relates to a missing s after http in two network get requests. The s was added to the http in the network requests as well as to the network requests in the Cypress testing suite.